### PR TITLE
Fix first link to quickstart from readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Read the full documentation on `read the docs <https://aws_ir.readthedocs.io/en/
 Quickstart
 ----------
 
-For more information see the `user guide <https://aws_ir.readthedocs.io/en/latest/user_guide.html>`__.
+For more information see the `quickstart <https://aws_ir.readthedocs.io/en/latest/quickstart.html>`__.
 
 Installation
 ************


### PR DESCRIPTION
refs: https://github.com/ThreatResponse/aws_ir/issues/62

The second link still points to the userguide, but the quickstart doesn't document all the subcommands so I left it as is for now.