### PR TITLE
Pass case profile in to Connection constructor

### DIFF
--- a/aws_ir/plans/host.py
+++ b/aws_ir/plans/host.py
@@ -77,7 +77,8 @@ class Compromise(object):
 
         session = connection.Connection(
             type='session',
-            region=compromised_resource['region']
+            region=compromised_resource['region'],
+            profile=self.case.profile
         ).connect()
 
         logger.info(


### PR DESCRIPTION
Fixes problem with 'default' profile being used with "session" variable
later in host.py

This call to the Connection instructor did not specify a value for "profile" (AWS connection profile), which led to the string "default" being used as the profile name instead of any profile passed in via `--profile` option. For users where the "default" profile was not the correct one to use, this could lead to undesired behavior