### PR TITLE
Use ==/!= to compare constant literals (str, bytes, int, float, tuple)

### DIFF
--- a/aws_ir/cli.py
+++ b/aws_ir/cli.py
@@ -218,7 +218,7 @@ class cli():
                     targets = f.read().split('\n')
 
                 for target in targets:
-                    if target is not '':
+                    if target != '':
                         hc = host.Compromise(
                             user=self.config.user,
                             ssh_key_file=self.config.ssh_key,

--- a/aws_ir/plans/host.py
+++ b/aws_ir/plans/host.py
@@ -47,7 +47,7 @@ class Compromise(object):
 
     def _target_type(self):
         """Returns the target type based on regex."""
-        if len(self.target.split('.')) is 4:
+        if len(self.target.split('.')) == 4:
             return 'ip-address'
         else:
             return 'instance-id'


### PR DESCRIPTION
Avoid [SyntaxWarnings on Python >= 3.8](https://docs.python.org/3/whatsnew/3.8.html#porting-to-python-3-8).

% `python3.8`
```
>>> '' is ''
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
```