### PR TITLE
Added code to take AWS credentials from environment variables

### DIFF
--- a/aws_ir/libs/connection.py
+++ b/aws_ir/libs/connection.py
@@ -1,5 +1,6 @@
 import boto3
 import logging
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -12,8 +13,25 @@ class Connection(object):
         self.client = None
         self.resource = None
         self.profile = profile
+        self.aws_access_key_id= os.getenv('AWS_ACCESS_KEY_ID', None)
+        self.aws_secret_access_key= os.getenv('AWS_SECRET_ACCESS_KEY', None)
+        self.aws_session_token = os.getenv('AWS_SESSION_TOKEN', None)
         try:
-            boto3.setup_default_session(profile_name=self.profile)
+            session_kwargs = {}
+            session_kwargs['profile_name'] = self.profile
+            if self.aws_access_key_id is not None:
+                session_kwargs["aws_access_key_id"] = self.aws_access_key_id
+                logger.debug("Took access key id from env")
+            if self.aws_secret_access_key is not None:
+                session_kwargs["aws_secret_access_key"] = self.aws_secret_access_key
+                logger.debug("Took secret access key from env")
+            if self.aws_session_token is not None:
+                session_kwargs["aws_session_token"] = self.aws_session_token
+                logger.debug("Took session token from env")
+            else:
+                session_kwargs['profile_name'] = self.profile
+                logger.debug("No session token in the env, setting profile name instead")
+            boto3.setup_default_session(**session_kwargs)
         except Exception as e:
             logger.info("Problem setting default boto3 session: {}".format(e))
 


### PR DESCRIPTION
This is helpful to most of the users who use credentials in the environment variables.

export AWS_ACCESS_KEY_ID=aaa
export AWS_SECRET_ACCESS_KEY=bbb
export AWS_SESSION_TOKEN=ccc

It covers a feature request for it (can't find it now, sorry), and make life of users easier
in this case by making aws_ir behave in a similar way like other standard and known
CLI tools for AWS: aws cli, cdk, ...

I am open for your comments!
